### PR TITLE
pymorphy3-dicts-ru 2.4.417150.4580142

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,3 @@
-aggregate_check: false
 upload_channels:
   - sk_test
 channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
+aggregate_check: false
 upload_channels:
   - sk_test
 channels:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,9 +34,9 @@ about:
   home: https://github.com/no-plagiarism/pymorphy3-dicts
   dev_url: https://github.com/no-plagiarism/pymorphy3-dicts
   doc_url: https://github.com/no-plagiarism/pymorphy3-dicts
-  summary: Ukrainian dictionaries for pymorphy3
+  summary: Russian dictionaries for pymorphy3
   description: |
-    Ukrainian dictionaries for pymorphy3
+    Russian dictionaries for pymorphy3
   license: GPL-3.0-or-later
   license_family: GPL
   license_url: https://github.com/no-plagiarism/pymorphy3-dicts/blob/master/LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: 39ab379d4ca905bafed50f5afc3a3de6f9643605776fbcabc4d3088d4ed382b0
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -32,9 +32,14 @@ test:
 
 about:
   home: https://github.com/no-plagiarism/pymorphy3-dicts
-  summary: Russian dictionaries for pymorphy2
-  license: MIT
-  license_file: PLEASE_ADD_LICENSE_FILE
+  dev_url: https://github.com/no-plagiarism/pymorphy3-dicts
+  doc_url: https://github.com/no-plagiarism/pymorphy3-dicts
+  summary: Ukrainian dictionaries for pymorphy3
+  description: |
+    Ukrainian dictionaries for pymorphy3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_url: https://github.com/no-plagiarism/pymorphy3-dicts/blob/master/LICENSE
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
License: https://github.com/no-plagiarism/pymorphy3-dicts/blob/master/LICENSE
Requirements: https://github.com/no-plagiarism/pymorphy3-dicts/blob/master/cookiecutter-pymorphy3-dicts/%7B%7B%20cookiecutter.distribution_name%20%7D%7D/setup.py

Notes:
- the package is a dependency of `pymorph3` and it's needed for resolving this issue https://github.com/conda-forge/spacy-models-feedstock/issues/2